### PR TITLE
Metabase v0.36.4 Upgrade

### DIFF
--- a/scripts/01-packages.sh
+++ b/scripts/01-packages.sh
@@ -10,7 +10,7 @@ apt-get -y autoclean
 apt-get install -y default-jdk
 
 # download and set permission for metabase
-wget http://downloads.metabase.com/v0.34.2/metabase.jar
+wget https://downloads.metabase.com/v0.36.4/metabase.jar
 mkdir /opt/metabase/
 mv metabase.jar /opt/metabase/metabase.jar
 chmod 775 /opt/metabase/metabase.jar


### PR DESCRIPTION
Bump to Metabase v0.36.4 and change URL to `https` as well.